### PR TITLE
Add canonical-compatible API (Config/Histogram/Sparse/Cumulative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,94 @@ The number of bins must be less than 2^32, and the largest encodable value must
 be less than 2^53.
 
 The histogram is designed to encode integer values only.
+
+## Two APIs
+
+This package ships two complementary surfaces:
+
+1. **`H2Encoding` / `H2HistogramBuilder` / `H2Histogram`** — the original
+   JavaScript-native API, parameterized by `{ a, b, n }`, where `a` sets the
+   width (`2^a`) of the linear buckets on the low end.
+
+2. **Canonical-compatible API** (`Config`, `Histogram`, `SparseHistogram`,
+   `CumulativeHistogram`, `Bucket`) — mirrors the iopsystems
+   [`histogram`](https://github.com/iopsystems/histogram) Rust crate (the
+   canonical implementation) and its
+   [Python](https://github.com/iopsystems/h2histogram-py) and
+   [Go](https://github.com/iopsystems/h2histogram-go) ports, using
+   `groupingPower` / `maxValuePower`.
+
+The two are interchangeable: a canonical `Config(groupingPower, maxValuePower)`
+is exactly `new H2Encoding({ a: 0, b: groupingPower, n: maxValuePower })` — the
+canonical implementation always uses width-1 linear buckets — so the canonical
+API reuses the same (property-tested) encoding under the hood and produces
+**byte-for-byte identical bucketing** to the Rust crate. This means a histogram
+recorded by Rezolus, or by the Python/Go implementations, can be loaded and
+analyzed here (and vice versa).
+
+### 53-bit values
+
+JavaScript numbers are 64-bit floats, so unlike the Rust/Go implementations
+(which support the full `u64` range up to `maxValuePower = 64`), this library
+caps `maxValuePower` at **53** — values up to `2^53 - 1`. Below that limit the
+bucketing is identical across all implementations.
+
+## Canonical API quick start
+
+```js
+import { Histogram } from 'h2-histogram';
+
+const h = new Histogram(7, 53); // groupingPower, maxValuePower (default 53)
+h.increment(42);
+h.record(1000, 5);              // value, count
+h.recordMany([12, 15, 900]);    // bulk
+
+h.totalCount();                 // 8
+
+const p99 = h.percentile(0.99); // a Bucket, or null if empty
+p99.range;                      // [lo, hi] inclusive
+p99.midpoint;                   // midpoint estimate
+
+// Combine / reduce
+const coarse = h.downsample(4); // fewer buckets, higher error, same total count
+const sparse = h.toSparse();    // columnar (index, count) form for storage
+```
+
+### Fast repeated quantile queries
+
+For a snapshot you'll query many times, convert to a `CumulativeHistogram`
+(the crate's `CumulativeROHistogram`). It stores non-zero buckets with
+**cumulative** counts, so percentiles are answered with a binary search, and it
+precomputes a midpoint-estimated `mean`:
+
+```js
+const c = h.toCumulative();      // read-only; also SparseHistogram#toCumulative()
+c.percentile(0.99);              // O(log n) -> Bucket (individual count)
+c.mean();                        // midpoint-estimated mean, computed once
+c.bucketQuantileRange(0);        // [lower, upper] quantile fraction of a stored bucket
+for (const [bucket, lo, hi] of c.iterWithQuantiles()) {
+  // each non-zero bucket with its quantile span
+}
+```
+
+### Interop with columnar (Rezolus) data
+
+```js
+import { Config, SparseHistogram, CumulativeHistogram } from 'h2-histogram';
+
+const config = new Config(3, 53);                 // Rezolus-style config
+const sparse = SparseHistogram.fromParts(config, bucketIndices, bucketCounts);
+const cumulative = sparse.toCumulative();
+cumulative.percentile(0.999);
+```
+
+## API overview
+
+| Type | Purpose |
+|------|---------|
+| `Config` | Bucketing parameters; `valueToIndex`, `indexToRange`, `totalBuckets`, `error`, `fromTotalBuckets` |
+| `Histogram` | Dense histogram; `increment`, `record`, `recordMany`, `percentile(s)`, `merge`, `subtract`, `downsample`, `toSparse`, `toCumulative`, `fromBuckets` |
+| `SparseHistogram` | Columnar `(index, count)` form; `fromHistogram`, `fromParts`, `toDense`, `toCumulative` |
+| `CumulativeHistogram` | Read-only cumulative form (crate's `CumulativeROHistogram`); binary-search `percentile(s)`, `mean`, `bucketQuantileRange`, `iterWithQuantiles` |
+| `Bucket` | A bucket's `count` and inclusive `[start, end]` range, plus `midpoint`/`width` |
+| `H2Encoding`, `H2HistogramBuilder`, `H2Histogram`, `encode32`, `decode32` | The original `{ a, b, n }` API (unchanged) |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# h2histogram
+
+> **Renamed:** this package was previously published as
+> [`h2-histogram`](https://www.npmjs.com/package/h2-histogram). It now lives at
+> [`h2histogram`](https://www.npmjs.com/package/h2histogram) to match the
+> [Python](https://github.com/iopsystems/h2histogram-py) and
+> [Go](https://github.com/iopsystems/h2histogram-go) packages. Install with
+> `npm install h2histogram`; the old `h2-histogram` package is deprecated and
+> will not receive further updates.
+
 The H2Histogram provides a histogram that is conceptually similar to
 [HdrHistogram](http://hdrhistogram.org) but with base-2 buckets, which makes it
 noticeably faster. This introduces small modifications to the configurable
@@ -48,7 +58,7 @@ bucketing is identical across all implementations.
 ## Canonical API quick start
 
 ```js
-import { Histogram } from 'h2-histogram';
+import { Histogram } from 'h2histogram';
 
 const h = new Histogram(7, 53); // groupingPower, maxValuePower (default 53)
 h.increment(42);
@@ -86,7 +96,7 @@ for (const [bucket, lo, hi] of c.iterWithQuantiles()) {
 ### Interop with columnar (Rezolus) data
 
 ```js
-import { Config, SparseHistogram, CumulativeHistogram } from 'h2-histogram';
+import { Config, SparseHistogram, CumulativeHistogram } from 'h2histogram';
 
 const config = new Config(3, 53);                 // Rezolus-style config
 const sparse = SparseHistogram.fromParts(config, bucketIndices, bucketCounts);

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing
+
+`h2histogram` is published to [npm](https://www.npmjs.com/package/h2histogram)
+by the [`npm-publish.yml`](.github/workflows/npm-publish.yml) GitHub Actions
+workflow. The workflow runs on every push to `main` and publishes **only when
+the head commit message matches `Release <version>` and the `package.json`
+version has changed**. It authenticates with the `NPM_AUTH_TOKEN` repository
+secret.
+
+## Cutting a release
+
+1. **Bump the version** in [`package.json`](package.json) following
+   [semantic versioning](https://semver.org/) (e.g. `1.2.0` → `1.2.1` for fixes,
+   `1.3.0` for backwards-compatible features). Do this on a branch and open a PR.
+2. **Land a `Release <version>` commit on `main`.** The publish trigger keys off
+   the commit *message*, so the commit that updates `package.json` (or the squash
+   merge) must be titled exactly:
+
+   ```
+   Release 1.2.0
+   ```
+
+   When it hits `main`, the workflow builds and runs `yarn publish`, then creates
+   a `v1.2.0` git tag.
+3. **Verify.** Within a minute or so:
+
+   ```bash
+   npm view h2histogram version   # -> 1.2.0
+   npm install h2histogram
+   ```
+
+> **Versions are immutable on npm.** A published version can never be
+> re-uploaded, only [deprecated](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions).
+> If you ship a bad release, bump the version and cut a new one.
+
+## The `h2-histogram` → `h2histogram` rename (one-time)
+
+This package was previously published as
+[`h2-histogram`](https://www.npmjs.com/package/h2-histogram). After the first
+`h2histogram` release, deprecate the old package so installs surface a pointer
+(run once, from an account with publish rights to the old package):
+
+```bash
+npm deprecate h2-histogram "renamed to h2histogram — install h2histogram instead"
+```
+
+This does not unpublish the old package (existing installs keep working); it just
+attaches a deprecation warning that npm prints on install.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "h2-histogram",
-  "version": "1.1.1",
+  "version": "1.2.0-alpha.1",
   "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "h2-histogram",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0",
   "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "type": "module",
-  "name": "h2-histogram",
+  "name": "h2histogram",
   "version": "1.2.0",
-  "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations.",
+  "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations. Byte-for-byte compatible with the iopsystems histogram Rust crate and its Python/Go ports.",
   "main": "src/index.js",
   "scripts": {
     "test": "vitest",
-    "build": "esbuild src/index.js --bundle --format=esm --outfile=dist/h2-histogram.js"
+    "build": "esbuild src/index.js --bundle --format=esm --outfile=dist/h2histogram.js"
   },
   "keywords": [],
   "author": "Yuri Vishnevsky",
@@ -23,10 +23,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/iopsystems/h2-histogram-js.git"
+    "url": "git+https://github.com/iopsystems/h2histogram-js.git"
   },
   "bugs": {
-    "url": "https://github.com/iopsystems/h2-histogram-js/issues"
+    "url": "https://github.com/iopsystems/h2histogram-js/issues"
   },
-  "homepage": "https://github.com/iopsystems/h2-histogram-js"
+  "homepage": "https://github.com/iopsystems/h2histogram-js"
 }

--- a/src/canonical.test.js
+++ b/src/canonical.test.js
@@ -1,0 +1,299 @@
+import { describe, expect, test } from 'vitest';
+import {
+  Bucket,
+  Config,
+  CumulativeHistogram,
+  H2Encoding,
+  Histogram,
+  SparseHistogram,
+  encode32,
+} from './index.js';
+
+// The canonical-compatible layer mirrors the iopsystems `histogram` crate and
+// its Python/Go ports. JS numbers are 64-bit floats, so we cap `maxValuePower`
+// at 53 rather than 64, but the bucketing below the maximum is identical.
+//
+// The value_to_index / index_to_bound assertions below are taken verbatim from
+// the Rust crate's `src/config.rs` unit tests. They are independent of
+// `max_value_power` (except for the final bucket), so with grouping_power=7 we
+// get byte-for-byte identical bucketing to the canonical crate.
+
+describe('Config', () => {
+  test('total buckets', () => {
+    expect(new Config(7, 53).totalBuckets).toBe(6016);
+    // A canonical Config is exactly H2Encoding with a = 0.
+    expect(new Config(7, 53).totalBuckets).toBe(new H2Encoding({ a: 0, b: 7, n: 53 }).numBins());
+    expect(new Config(3, 53).totalBuckets).toBe(new H2Encoding({ a: 0, b: 3, n: 53 }).numBins());
+  });
+
+  test('valueToIndex matches the Rust crate', () => {
+    const c = new Config(7, 53);
+    expect(c.valueToIndex(0)).toBe(0);
+    expect(c.valueToIndex(1)).toBe(1);
+    expect(c.valueToIndex(256)).toBe(256);
+    expect(c.valueToIndex(257)).toBe(256);
+    expect(c.valueToIndex(258)).toBe(257);
+    expect(c.valueToIndex(512)).toBe(384);
+    expect(c.valueToIndex(515)).toBe(384);
+    expect(c.valueToIndex(516)).toBe(385);
+    expect(c.valueToIndex(1024)).toBe(512);
+    expect(c.valueToIndex(1031)).toBe(512);
+    expect(c.valueToIndex(1032)).toBe(513);
+  });
+
+  test('valueToIndex agrees with encode32 (a=0)', () => {
+    const c = new Config(7, 53);
+    for (const v of [0, 1, 255, 256, 257, 1000, 65535, 65536, 1 << 20, (1 << 30) - 1]) {
+      expect(c.valueToIndex(v)).toBe(encode32(v, 0, 7));
+    }
+  });
+
+  test('index to bounds match the Rust crate', () => {
+    const c = new Config(7, 53);
+    expect(c.indexToLowerBound(0)).toBe(0);
+    expect(c.indexToLowerBound(1)).toBe(1);
+    expect(c.indexToLowerBound(256)).toBe(256);
+    expect(c.indexToLowerBound(384)).toBe(512);
+    expect(c.indexToLowerBound(512)).toBe(1024);
+
+    expect(c.indexToUpperBound(0)).toBe(0);
+    expect(c.indexToUpperBound(1)).toBe(1);
+    expect(c.indexToUpperBound(256)).toBe(257);
+    expect(c.indexToUpperBound(384)).toBe(515);
+    expect(c.indexToUpperBound(512)).toBe(1031);
+
+    expect(c.indexToRange(256)).toEqual([256, 257]);
+    // The last bucket's upper bound is the configured maximum.
+    expect(c.indexToUpperBound(c.totalBuckets - 1)).toBe(2 ** 53 - 1);
+  });
+
+  test('roundtrip value -> index -> range contains the value', () => {
+    const c = new Config(7, 53);
+    for (const value of [0, 1, 5, 127, 128, 255, 256, 257, 999, 1_000_000, 2 ** 40 + 7, 2 ** 52 + 3]) {
+      const idx = c.valueToIndex(value);
+      const [lo, hi] = c.indexToRange(idx);
+      expect(lo <= value && value <= hi).toBe(true);
+    }
+  });
+
+  test('error', () => {
+    expect(new Config(7, 53).error()).toBeCloseTo(100 / 128, 12);
+    expect(new Config(3, 4).error()).toBe(0);
+  });
+
+  test('invalid params', () => {
+    expect(() => new Config(7, 54)).toThrow(); // exceeds JS 53-bit limit
+    expect(() => new Config(53, 53)).toThrow(); // grouping >= max
+    expect(() => new Config(10, 5)).toThrow();
+  });
+
+  test('fromTotalBuckets', () => {
+    const c = Config.fromTotalBuckets(6016, 53);
+    expect(c.groupingPower).toBe(7);
+    expect(c.maxValuePower).toBe(53);
+    expect(() => Config.fromTotalBuckets(6017, 53)).toThrow();
+  });
+});
+
+describe('Histogram', () => {
+  test('increment and total', () => {
+    const h = new Histogram(7, 53);
+    for (let i = 0; i <= 100; i++) h.increment(i);
+    expect(h.totalCount()).toBe(101);
+  });
+
+  test('record with count', () => {
+    const h = new Histogram(7, 53);
+    h.record(100, 5);
+    expect(h.totalCount()).toBe(5);
+    expect(h.buckets[h.config.valueToIndex(100)]).toBe(5);
+  });
+
+  test('percentile exact in linear region', () => {
+    const h = new Histogram(7, 53);
+    for (let i = 1; i <= 100; i++) h.increment(i);
+    expect(h.percentile(0.5)).toEqual(new Bucket(1, 50, 50));
+    expect(h.percentile(1.0)).toEqual(new Bucket(1, 100, 100));
+    expect(h.percentile(0.0)).toEqual(new Bucket(1, 1, 1));
+  });
+
+  test('percentile empty', () => {
+    const h = new Histogram(7, 53);
+    expect(h.percentile(0.5)).toBeNull();
+    expect(h.percentiles([0.5, 0.9])).toBeNull();
+  });
+
+  test('percentiles preserve requested order', () => {
+    const h = new Histogram(7, 53);
+    for (let i = 0; i < 1000; i++) h.increment(i);
+    const result = h.percentiles([0.9, 0.5, 0.99]) ?? [];
+    expect(result.map(([p]) => p)).toEqual([0.9, 0.5, 0.99]);
+  });
+
+  test('percentile invalid', () => {
+    const h = new Histogram(7, 53);
+    h.increment(1);
+    expect(() => h.percentile(1.5)).toThrow();
+  });
+
+  test('merge', () => {
+    const a = new Histogram(7, 53);
+    const b = new Histogram(7, 53);
+    a.record(10, 3);
+    b.record(10, 4);
+    b.record(2000, 1);
+    const merged = a.merge(b);
+    expect(merged.totalCount()).toBe(8);
+    expect(merged.buckets[merged.config.valueToIndex(10)]).toBe(7);
+  });
+
+  test('merge incompatible', () => {
+    expect(() => new Histogram(7, 53).merge(new Histogram(6, 53))).toThrow();
+  });
+
+  test('subtract', () => {
+    const a = new Histogram(7, 53);
+    const b = new Histogram(7, 53);
+    a.record(10, 5);
+    b.record(10, 2);
+    expect(a.subtract(b).totalCount()).toBe(3);
+    expect(() => b.subtract(a)).toThrow();
+  });
+
+  test('fromBuckets roundtrip', () => {
+    const h = new Histogram(3, 53);
+    h.record(5, 2);
+    h.record(1000, 7);
+    const h2 = Histogram.fromBuckets(3, 53, h.buckets);
+    expect(h.equals(h2)).toBe(true);
+  });
+
+  test('fromBuckets wrong length', () => {
+    expect(() => Histogram.fromBuckets(7, 53, [0, 0, 0])).toThrow();
+  });
+
+  test('downsample', () => {
+    const h = new Histogram(7, 53);
+    for (let i = 0; i < 10000; i++) h.increment(i);
+    const coarse = h.downsample(3);
+    expect(coarse.config.groupingPower).toBe(3);
+    expect(coarse.totalCount()).toBe(h.totalCount());
+    expect(() => h.downsample(7)).toThrow();
+  });
+
+  test('recordMany matches loop', () => {
+    const base = [0, 1, 2, 300, 255, 256, 1024, 1_000_000, 2 ** 50 + 3];
+    const values = [];
+    for (let i = 0; i < 111; i++) values.push(...base);
+    const a = new Histogram(7, 53);
+    for (const v of values) a.increment(v);
+    const b = new Histogram(7, 53);
+    b.recordMany(values);
+    expect(a.equals(b)).toBe(true);
+  });
+
+  test('recordMany with counts', () => {
+    const a = new Histogram(7, 53);
+    a.recordMany([10, 20, 10], [2, 3, 5]);
+    expect(a.totalCount()).toBe(10);
+    expect(a.buckets[a.config.valueToIndex(10)]).toBe(7);
+  });
+
+  test('iterate buckets', () => {
+    const h = new Histogram(3, 6);
+    h.increment(0);
+    const all = [...h];
+    expect(all.length).toBe(h.config.totalBuckets);
+    expect(all.every((b) => b instanceof Bucket)).toBe(true);
+    const nonzero = h.nonzeroBuckets();
+    expect(nonzero.length).toBe(1);
+    expect(nonzero[0].count).toBe(1);
+  });
+});
+
+describe('SparseHistogram', () => {
+  test('roundtrip', () => {
+    const h = new Histogram(7, 53);
+    h.record(1, 1);
+    h.record(500, 3);
+    h.record(999999, 2);
+    const sparse = h.toSparse();
+    expect(sparse).toBeInstanceOf(SparseHistogram);
+    expect(sparse.totalCount()).toBe(h.totalCount());
+    expect(sparse.length).toBe(3);
+    expect([...sparse.index]).toEqual([...sparse.index].sort((a, b) => a - b));
+    expect(sparse.toDense().equals(h)).toBe(true);
+  });
+
+  test('fromParts validation', () => {
+    const c = new Config(7, 53);
+    expect(() => SparseHistogram.fromParts(c, [1, 2], [1])).toThrow();
+    expect(() => SparseHistogram.fromParts(c, [2, 1], [1, 1])).toThrow();
+    expect(() => SparseHistogram.fromParts(c, [999999999], [1])).toThrow();
+  });
+});
+
+describe('CumulativeHistogram', () => {
+  test('cumulative counts are prefix sums', () => {
+    const h = new Histogram(7, 53);
+    h.record(1, 2);
+    h.record(500, 3);
+    h.record(1_000_000, 5);
+    const c = h.toCumulative();
+    expect(c.totalCount()).toBe(10);
+    expect(c.length).toBe(3);
+    expect([...c.count]).toEqual([2, 5, 10]);
+  });
+
+  test('percentile matches dense', () => {
+    const h = new Histogram(7, 53);
+    for (let i = 1; i <= 1000; i++) h.increment(i);
+    const c = h.toCumulative();
+    for (const q of [0.0, 0.1, 0.5, 0.9, 0.99, 1.0]) {
+      const dense = h.percentile(q);
+      const cum = c.percentile(q);
+      expect(cum?.range).toEqual(dense?.range);
+    }
+  });
+
+  test('empty', () => {
+    const c = new Histogram(7, 53).toCumulative();
+    expect(c.isEmpty()).toBe(true);
+    expect(c.percentile(0.5)).toBeNull();
+    expect(c.mean()).toBeNull();
+  });
+
+  test('mean (exact in linear region)', () => {
+    const h = new Histogram(7, 53);
+    h.record(10, 1);
+    h.record(20, 1);
+    h.record(30, 1);
+    expect(h.toCumulative().mean()).toBeCloseTo(20, 9);
+  });
+
+  test('fromParts validation', () => {
+    const c = new Config(7, 53);
+    expect(CumulativeHistogram.fromParts(c, [1, 256], [3, 8]).totalCount()).toBe(8);
+    expect(() => CumulativeHistogram.fromParts(c, [1], [0])).toThrow();
+    expect(() => CumulativeHistogram.fromParts(c, [1, 2], [5, 3])).toThrow();
+  });
+
+  test('bucketQuantileRange', () => {
+    const h = new Histogram(7, 53);
+    h.record(10, 2);
+    h.record(20, 2);
+    const c = h.toCumulative();
+    expect(c.bucketQuantileRange(0)).toEqual([0, 0.5]);
+    expect(c.bucketQuantileRange(1)).toEqual([0.5, 1.0]);
+    expect(c.bucketQuantileRange(99)).toBeNull();
+  });
+
+  test('fromSparse roundtrip', () => {
+    const h = new Histogram(7, 53);
+    h.record(1, 1);
+    h.record(500, 3);
+    const c = h.toSparse().toCumulative();
+    expect(c.totalCount()).toBe(4);
+    expect(c.toDense().equals(h)).toBe(true);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -568,3 +568,772 @@ function assertSafeInteger(x) {
 function assertDefined(x) {
   assert(x !== undefined, 'expected a defined value, got undefined');
 };
+
+// ---------------------------------------------------------------------------
+// Canonical-compatible API
+// ---------------------------------------------------------------------------
+//
+// The types below mirror the iopsystems `histogram` crate (the canonical Rust
+// implementation) and its Python and Go ports, using the same
+// `groupingPower` / `maxValuePower` parameters and the same `Config`,
+// `Histogram`, `SparseHistogram`, `CumulativeHistogram` and `Bucket` surface.
+//
+// In the crate's terms, the linear region always uses width-1 buckets, which
+// corresponds to `a = 0` in the `H2Encoding` above. So a canonical `Config`
+// with `groupingPower = g` and `maxValuePower = n` is exactly
+// `new H2Encoding({ a: 0, b: g, n })`, and this layer reuses that
+// (property-tested) encoding to guarantee byte-for-byte identical bucketing.
+//
+// The one deviation from the canonical implementation is the value range:
+// JavaScript numbers are 64-bit floats, so the largest `maxValuePower` we
+// support is 53 (values up to 2^53 - 1) rather than 64.
+
+/** The largest `maxValuePower` representable with 64-bit float integers. */
+export const MAX_VALUE_POWER = 53;
+
+/**
+ * Immutable bucketing configuration, equivalent to the crate's `Config`.
+ *
+ * Construct with `Config.new(groupingPower, maxValuePower)`.
+ */
+export class Config {
+  /**
+   * @param {number} groupingPower - number of buckets spanning each power of
+   *   two; the relative error is `2^-groupingPower`.
+   * @param {number} [maxValuePower] - largest representable value is
+   *   `2^maxValuePower - 1` (default 53, the JS maximum).
+   */
+  constructor(groupingPower, maxValuePower = MAX_VALUE_POWER) {
+    assertSafeInteger(groupingPower);
+    assertSafeInteger(maxValuePower);
+    assert(maxValuePower <= MAX_VALUE_POWER, () => `max_value_power must be <= ${MAX_VALUE_POWER}, got ${maxValuePower}`);
+    assert(groupingPower >= 0 && maxValuePower >= 0, () => `grouping_power and max_value_power must be non-negative`);
+    assert(groupingPower < maxValuePower, () => `grouping_power (${groupingPower}) must be less than max_value_power (${maxValuePower})`);
+
+    this.groupingPower = groupingPower;
+    this.maxValuePower = maxValuePower;
+    // The linear region uses width-1 buckets, i.e. a = 0 in H2Encoding terms.
+    this.encoding = new H2Encoding({ a: 0, b: groupingPower, n: maxValuePower });
+    this.cutoffPower = groupingPower + 1;
+    this.cutoffValue = 2 ** this.cutoffPower;
+    this.max = this.encoding.maxValue();
+  }
+
+  /**
+   * Create and validate a Config. Mirrors the crate's constructor.
+   * @param {number} groupingPower
+   * @param {number} [maxValuePower]
+   */
+  static new(groupingPower, maxValuePower = MAX_VALUE_POWER) {
+    return new Config(groupingPower, maxValuePower);
+  }
+
+  /**
+   * Infer a config from a known bucket count and `maxValuePower`. Useful for
+   * dense columns that store only the counts. Throws if no grouping power
+   * produces `totalBuckets`.
+   * @param {number} totalBuckets
+   * @param {number} [maxValuePower]
+   */
+  static fromTotalBuckets(totalBuckets, maxValuePower = MAX_VALUE_POWER) {
+    for (let groupingPower = 0; groupingPower < maxValuePower; groupingPower++) {
+      const candidate = new Config(groupingPower, maxValuePower);
+      if (candidate.totalBuckets === totalBuckets) {
+        return candidate;
+      }
+    }
+    throw new Error(`no grouping_power with max_value_power=${maxValuePower} yields ${totalBuckets} buckets`);
+  }
+
+  /** Total number of buckets for this configuration. */
+  get totalBuckets() {
+    return this.encoding.numBins();
+  }
+
+  /**
+   * Relative error (as a percentage) of the logarithmic buckets. Linear
+   * buckets have width 1 and no error; a config with no logarithmic buckets
+   * has zero error.
+   */
+  error() {
+    if (this.groupingPower === this.maxValuePower - 1) {
+      return 0.0;
+    }
+    return 100.0 / 2 ** this.groupingPower;
+  }
+
+  /**
+   * Return the bucket index that `value` falls into. Throws if the value is
+   * out of range.
+   * @param {number} value
+   */
+  valueToIndex(value) {
+    return this.encoding.encode(value);
+  }
+
+  /**
+   * Inclusive lower bound of the bucket at `index`.
+   * @param {number} index
+   */
+  indexToLowerBound(index) {
+    return this.encoding.lower(index);
+  }
+
+  /**
+   * Inclusive upper bound of the bucket at `index`.
+   * @param {number} index
+   */
+  indexToUpperBound(index) {
+    return this.encoding.upper(index);
+  }
+
+  /**
+   * Inclusive `[lower, upper]` range for the bucket at `index`.
+   * @param {number} index
+   */
+  indexToRange(index) {
+    return [this.indexToLowerBound(index), this.indexToUpperBound(index)];
+  }
+
+  /**
+   * @param {Config} other
+   */
+  equals(other) {
+    return other instanceof Config
+      && this.groupingPower === other.groupingPower
+      && this.maxValuePower === other.maxValuePower;
+  }
+}
+
+/**
+ * A single histogram bucket: a count and an inclusive value range.
+ */
+export class Bucket {
+  /**
+   * @param {number} count
+   * @param {number} start - inclusive lower bound
+   * @param {number} end - inclusive upper bound
+   */
+  constructor(count, start, end) {
+    this.count = count;
+    this.start = start;
+    this.end = end;
+  }
+
+  /** The inclusive `[start, end]` range of the bucket. */
+  get range() {
+    return [this.start, this.end];
+  }
+
+  /** Arithmetic midpoint of the range; a reasonable point estimate. */
+  get midpoint() {
+    return (this.start + this.end) / 2;
+  }
+
+  /** Number of distinct integer values the bucket covers. */
+  get width() {
+    return this.end - this.start + 1;
+  }
+}
+
+/**
+ * A dense h2 histogram with a counter for every bucket.
+ *
+ * This is the JS analogue of the crate's `Histogram`. Counts are stored in a
+ * `Float64Array`, so per-bucket counts are exact up to 2^53.
+ */
+export class Histogram {
+  /**
+   * @param {number} groupingPower
+   * @param {number} [maxValuePower]
+   * @param {{ config?: Config }} [options]
+   */
+  constructor(groupingPower, maxValuePower = MAX_VALUE_POWER, { config } = {}) {
+    this.config = config ?? new Config(groupingPower, maxValuePower);
+    this.buckets = new Float64Array(this.config.totalBuckets);
+  }
+
+  /**
+   * Create an empty histogram from an existing Config.
+   * @param {Config} config
+   */
+  static withConfig(config) {
+    return new Histogram(config.groupingPower, config.maxValuePower, { config });
+  }
+
+  /**
+   * Create a histogram from a full, dense list of bucket counts.
+   * @param {number} groupingPower
+   * @param {number} maxValuePower
+   * @param {number[] | Float64Array} buckets
+   */
+  static fromBuckets(groupingPower, maxValuePower, buckets) {
+    const config = new Config(groupingPower, maxValuePower);
+    assert(buckets.length === config.totalBuckets, () => `expected ${config.totalBuckets} buckets, got ${buckets.length}`);
+    const h = Histogram.withConfig(config);
+    h.buckets.set(buckets);
+    return h;
+  }
+
+  /** Total number of observations recorded. */
+  totalCount() {
+    let total = 0;
+    for (let i = 0; i < this.buckets.length; i++) {
+      total += this.buckets[i];
+    }
+    return total;
+  }
+
+  /**
+   * Add one observation of `value` (or `count` observations).
+   * @param {number} value
+   * @param {number} [count]
+   */
+  increment(value, count = 1) {
+    this.buckets[this.config.valueToIndex(value)] += count;
+  }
+
+  /**
+   * Add `count` observations of `value`. Alias for `increment`.
+   * @param {number} value
+   * @param {number} [count]
+   */
+  record(value, count = 1) {
+    this.increment(value, count);
+  }
+
+  /**
+   * Record many values at once. If `counts` is provided it must be the same
+   * length as `values` and supplies a weight for each value.
+   * @param {Iterable<number>} values
+   * @param {Iterable<number>} [counts]
+   */
+  recordMany(values, counts) {
+    if (counts !== undefined) {
+      const vi = values[Symbol.iterator]();
+      const ci = counts[Symbol.iterator]();
+      while (true) {
+        const v = vi.next();
+        const c = ci.next();
+        if (v.done || c.done) break;
+        this.record(v.value, c.value);
+      }
+      return;
+    }
+    for (const value of values) {
+      this.increment(value);
+    }
+  }
+
+  /** Iterate every bucket (including empty ones) as `Bucket` objects. */
+  *[Symbol.iterator]() {
+    for (let i = 0; i < this.buckets.length; i++) {
+      const [start, end] = this.config.indexToRange(i);
+      yield new Bucket(this.buckets[i], start, end);
+    }
+  }
+
+  /** Return only the buckets with a non-zero count. */
+  nonzeroBuckets() {
+    const out = [];
+    for (let i = 0; i < this.buckets.length; i++) {
+      if (this.buckets[i] > 0) {
+        const [start, end] = this.config.indexToRange(i);
+        out.push(new Bucket(this.buckets[i], start, end));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * @param {Histogram} other
+   */
+  _checkCompatible(other) {
+    assert(this.config.equals(other.config), () => `histograms have incompatible configurations`);
+  }
+
+  /**
+   * Return a new histogram that is the element-wise sum of both. Both must
+   * share the same configuration.
+   * @param {Histogram} other
+   */
+  merge(other) {
+    this._checkCompatible(other);
+    const result = Histogram.withConfig(this.config);
+    for (let i = 0; i < this.buckets.length; i++) {
+      result.buckets[i] = this.buckets[i] + other.buckets[i];
+    }
+    return result;
+  }
+
+  /**
+   * Return a new histogram that is the element-wise difference. Throws if any
+   * bucket would go negative.
+   * @param {Histogram} other
+   */
+  subtract(other) {
+    this._checkCompatible(other);
+    const result = Histogram.withConfig(this.config);
+    for (let i = 0; i < this.buckets.length; i++) {
+      const diff = this.buckets[i] - other.buckets[i];
+      assert(diff >= 0, () => `subtraction would produce a negative bucket count`);
+      result.buckets[i] = diff;
+    }
+    return result;
+  }
+
+  /**
+   * Return a coarser histogram with a smaller `groupingPower`. The new
+   * grouping power must be strictly less than the current one.
+   * @param {number} groupingPower
+   */
+  downsample(groupingPower) {
+    assert(groupingPower < this.config.groupingPower, () => `target grouping_power must be less than the current grouping_power`);
+    const result = new Histogram(groupingPower, this.config.maxValuePower);
+    for (let i = 0; i < this.buckets.length; i++) {
+      const count = this.buckets[i];
+      if (count > 0) {
+        result.record(this.config.indexToLowerBound(i), count);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Return the bucket at a single `percentile` in [0, 1], or `null` if the
+   * histogram is empty. `0.5` is the median (same convention as the crate).
+   * @param {number} percentile
+   */
+  percentile(percentile) {
+    const result = this.percentiles([percentile]);
+    return result === null ? null : result[0][1];
+  }
+
+  /**
+   * Return `[percentile, Bucket]` pairs for each requested percentile, in the
+   * original order. Returns `null` if the histogram is empty.
+   * @param {number[]} percentiles
+   * @returns {[number, Bucket][] | null}
+   */
+  percentiles(percentiles) {
+    for (const p of percentiles) {
+      assert(p >= 0 && p <= 1, () => `percentiles must be in the range [0, 1], got ${p}`);
+    }
+    const total = this.totalCount();
+    if (total === 0) {
+      return null;
+    }
+
+    const sortedUnique = Array.from(new Set(percentiles)).sort((x, y) => x - y);
+    /** @type {Map<number, Bucket>} */
+    const results = new Map();
+    let bucketIdx = 0;
+    let partialSum = this.buckets[0];
+
+    for (const p of sortedUnique) {
+      const target = Math.max(1, Math.ceil(p * total));
+      while (true) {
+        if (partialSum >= target || bucketIdx === this.buckets.length - 1) {
+          const [start, end] = this.config.indexToRange(bucketIdx);
+          results.set(p, new Bucket(this.buckets[bucketIdx], start, end));
+          break;
+        }
+        bucketIdx += 1;
+        partialSum += this.buckets[bucketIdx];
+      }
+    }
+
+    /** @type {[number, Bucket][]} */
+    const out = [];
+    for (const p of percentiles) {
+      out.push([p, /** @type {Bucket} */ (results.get(p))]);
+    }
+    return out;
+  }
+
+  /**
+   * Alias for `percentile` (the crate uses `quantile`).
+   * @param {number} quantile
+   */
+  quantile(quantile) {
+    return this.percentile(quantile);
+  }
+
+  /** Convert to the sparse (columnar) representation. */
+  toSparse() {
+    return SparseHistogram.fromHistogram(this);
+  }
+
+  /** Convert to a read-only cumulative histogram for fast quantiles. */
+  toCumulative() {
+    return CumulativeHistogram.fromHistogram(this);
+  }
+
+  /**
+   * @param {Histogram} other
+   */
+  equals(other) {
+    if (!(other instanceof Histogram) || !this.config.equals(other.config)) {
+      return false;
+    }
+    if (this.buckets.length !== other.buckets.length) {
+      return false;
+    }
+    for (let i = 0; i < this.buckets.length; i++) {
+      if (this.buckets[i] !== other.buckets[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/**
+ * Sparse, columnar representation storing only non-zero buckets as parallel
+ * `index` / `count` arrays in ascending index order. Equivalent to the crate's
+ * `SparseHistogram` and the form Rezolus uses for its columnar layout.
+ */
+export class SparseHistogram {
+  /**
+   * @param {Config} config
+   * @param {number[]} index
+   * @param {number[]} count
+   */
+  constructor(config, index = [], count = []) {
+    this.config = config;
+    this.index = index;
+    this.count = count;
+  }
+
+  /**
+   * Build a sparse histogram from a dense Histogram.
+   * @param {Histogram} histogram
+   */
+  static fromHistogram(histogram) {
+    const index = [];
+    const count = [];
+    for (let i = 0; i < histogram.buckets.length; i++) {
+      const c = histogram.buckets[i];
+      if (c > 0) {
+        index.push(i);
+        count.push(c);
+      }
+    }
+    return new SparseHistogram(histogram.config, index, count);
+  }
+
+  /**
+   * Create a sparse histogram from raw parts, validating invariants.
+   * @param {Config} config
+   * @param {number[] | Uint32Array} index
+   * @param {number[] | Float64Array} count
+   */
+  static fromParts(config, index, count) {
+    assert(index.length === count.length, () => `index and count must have the same length`);
+    const total = config.totalBuckets;
+    let prev = -1;
+    for (const i of index) {
+      assert(i >= 0 && i < total, () => `index ${i} out of range for config`);
+      assert(i > prev, () => `indices must be strictly ascending`);
+      prev = i;
+    }
+    return new SparseHistogram(config, Array.from(index), Array.from(count));
+  }
+
+  get length() {
+    return this.index.length;
+  }
+
+  isEmpty() {
+    return this.index.length === 0;
+  }
+
+  totalCount() {
+    let total = 0;
+    for (const c of this.count) {
+      total += c;
+    }
+    return total;
+  }
+
+  /** Iterate non-zero buckets as `Bucket` objects. */
+  *[Symbol.iterator]() {
+    for (let k = 0; k < this.index.length; k++) {
+      const [start, end] = this.config.indexToRange(this.index[k]);
+      yield new Bucket(this.count[k], start, end);
+    }
+  }
+
+  /** Convert to a dense Histogram. */
+  toDense() {
+    const h = Histogram.withConfig(this.config);
+    for (let k = 0; k < this.index.length; k++) {
+      h.buckets[this.index[k]] = this.count[k];
+    }
+    return h;
+  }
+
+  /** Convert to a read-only CumulativeHistogram. */
+  toCumulative() {
+    return CumulativeHistogram.fromSparse(this);
+  }
+
+  /**
+   * @param {number} percentile
+   */
+  percentile(percentile) {
+    return this.toDense().percentile(percentile);
+  }
+
+  /**
+   * @param {number[]} percentiles
+   */
+  percentiles(percentiles) {
+    return this.toDense().percentiles(percentiles);
+  }
+}
+
+/**
+ * Read-only histogram with cumulative counts for fast quantile queries.
+ * Corresponds to the crate's `CumulativeROHistogram`: it stores only non-zero
+ * buckets, but `count[i]` is the running prefix sum, so percentile queries are
+ * answered with a binary search (O(log n)). A midpoint-estimated `mean` is
+ * computed once at construction.
+ */
+export class CumulativeHistogram {
+  /**
+   * @param {Config} config
+   * @param {number[]} index
+   * @param {number[]} count - cumulative (prefix-sum) counts
+   * @param {{ validate?: boolean }} [options]
+   */
+  constructor(config, index, count, { validate = true } = {}) {
+    this.config = config;
+    this.index = index;
+    this.count = count;
+    if (validate) {
+      this._validate();
+    }
+    this._mean = this._computeMean();
+  }
+
+  /**
+   * Create from raw parts. `count` must be cumulative (prefix sums).
+   * @param {Config} config
+   * @param {number[]} index
+   * @param {number[]} count
+   */
+  static fromParts(config, index, count) {
+    return new CumulativeHistogram(config, Array.from(index), Array.from(count));
+  }
+
+  /**
+   * Build from a dense Histogram.
+   * @param {Histogram} histogram
+   */
+  static fromHistogram(histogram) {
+    const index = [];
+    const count = [];
+    let running = 0;
+    for (let i = 0; i < histogram.buckets.length; i++) {
+      const n = histogram.buckets[i];
+      if (n > 0) {
+        running += n;
+        index.push(i);
+        count.push(running);
+      }
+    }
+    return new CumulativeHistogram(histogram.config, index, count, { validate: false });
+  }
+
+  /**
+   * Build from a SparseHistogram.
+   * @param {SparseHistogram} sparse
+   */
+  static fromSparse(sparse) {
+    const index = Array.from(sparse.index);
+    const count = [];
+    let running = 0;
+    for (const n of sparse.count) {
+      running += n;
+      count.push(running);
+    }
+    return new CumulativeHistogram(sparse.config, index, count, { validate: false });
+  }
+
+  _validate() {
+    assert(this.index.length === this.count.length, () => `index and count must have the same length`);
+    const total = this.config.totalBuckets;
+    let prev = -1;
+    for (const i of this.index) {
+      assert(i >= 0 && i < total, () => `index ${i} out of range for config`);
+      assert(i > prev, () => `indices must be strictly ascending`);
+      prev = i;
+    }
+    let prevC = null;
+    for (const c of this.count) {
+      assert(c !== 0, () => `cumulative counts must be non-zero`);
+      assert(prevC === null || c >= prevC, () => `cumulative counts must be non-decreasing`);
+      prevC = c;
+    }
+  }
+
+  /**
+   * @param {number} position
+   */
+  _individualCount(position) {
+    return position === 0 ? this.count[0] : this.count[position] - this.count[position - 1];
+  }
+
+  _computeMean() {
+    if (this.count.length === 0) {
+      return null;
+    }
+    const total = this.count[this.count.length - 1];
+    if (total === 0) {
+      return null;
+    }
+    let weighted = 0;
+    for (let i = 0; i < this.index.length; i++) {
+      const [start, end] = this.config.indexToRange(this.index[i]);
+      weighted += ((start + end) / 2) * this._individualCount(i);
+    }
+    return weighted / total;
+  }
+
+  get length() {
+    return this.index.length;
+  }
+
+  isEmpty() {
+    return this.index.length === 0;
+  }
+
+  totalCount() {
+    return this.count.length === 0 ? 0 : this.count[this.count.length - 1];
+  }
+
+  /** Midpoint-estimated mean of all observations, or `null` if empty. */
+  mean() {
+    return this._mean;
+  }
+
+  /**
+   * First position whose cumulative count is >= `target`.
+   * @param {number} target
+   */
+  _findQuantilePosition(target) {
+    const pos = bisectLeft(this.count, target);
+    return Math.min(pos, this.count.length - 1);
+  }
+
+  /**
+   * Return the Bucket at `percentile` in [0, 1] (individual count), or `null`
+   * if the histogram is empty.
+   * @param {number} percentile
+   */
+  percentile(percentile) {
+    const result = this.percentiles([percentile]);
+    return result === null ? null : result[0][1];
+  }
+
+  /**
+   * Return `[percentile, Bucket]` pairs, one per requested percentile.
+   * @param {number[]} percentiles
+   * @returns {[number, Bucket][] | null}
+   */
+  percentiles(percentiles) {
+    for (const p of percentiles) {
+      assert(p >= 0 && p <= 1, () => `percentiles must be in the range [0, 1], got ${p}`);
+    }
+    if (this.count.length === 0) {
+      return null;
+    }
+    const total = this.count[this.count.length - 1];
+    if (total === 0) {
+      return null;
+    }
+    /** @type {[number, Bucket][]} */
+    const out = [];
+    for (const p of percentiles) {
+      const target = Math.max(1, Math.ceil(p * total));
+      const pos = this._findQuantilePosition(target);
+      const [start, end] = this.config.indexToRange(this.index[pos]);
+      out.push([p, new Bucket(this._individualCount(pos), start, end)]);
+    }
+    return out;
+  }
+
+  /**
+   * @param {number} quantile
+   */
+  quantile(quantile) {
+    return this.percentile(quantile);
+  }
+
+  /**
+   * Return `[lower, upper]` quantile fractions for the `bucketIdx`-th stored
+   * bucket, or `null` if empty or out of range.
+   * @param {number} bucketIdx
+   */
+  bucketQuantileRange(bucketIdx) {
+    if (bucketIdx < 0 || bucketIdx >= this.count.length) {
+      return null;
+    }
+    const total = this.count[this.count.length - 1];
+    if (total === 0) {
+      return null;
+    }
+    const lower = bucketIdx === 0 ? 0 : this.count[bucketIdx - 1] / total;
+    const upper = this.count[bucketIdx] / total;
+    return [lower, upper];
+  }
+
+  /** Iterate non-zero buckets (with individual counts) as `Bucket` objects. */
+  *[Symbol.iterator]() {
+    for (let i = 0; i < this.index.length; i++) {
+      const [start, end] = this.config.indexToRange(this.index[i]);
+      yield new Bucket(this._individualCount(i), start, end);
+    }
+  }
+
+  /** Iterate `[Bucket, lowerQuantile, upperQuantile]` per non-zero bucket. */
+  *iterWithQuantiles() {
+    const total = this.count.length === 0 ? 0 : this.count[this.count.length - 1];
+    for (let i = 0; i < this.index.length; i++) {
+      const lower = i === 0 ? 0 : this.count[i - 1] / total;
+      const upper = this.count[i] / total;
+      const [start, end] = this.config.indexToRange(this.index[i]);
+      yield [new Bucket(this._individualCount(i), start, end), lower, upper];
+    }
+  }
+
+  /** Reconstruct a dense Histogram. */
+  toDense() {
+    const h = Histogram.withConfig(this.config);
+    for (let i = 0; i < this.index.length; i++) {
+      h.buckets[this.index[i]] = this._individualCount(i);
+    }
+    return h;
+  }
+}
+
+/**
+ * Return the leftmost index at which `target` could be inserted into the sorted
+ * array `arr` to keep it sorted, i.e. the first index `i` with `arr[i] >= target`.
+ * @param {number[] | Float64Array} arr
+ * @param {number} target
+ */
+function bisectLeft(arr, target) {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}


### PR DESCRIPTION
## Summary

Adds a canonical-compatible API surface so the JS library interoperates with the iopsystems [`histogram`](https://github.com/iopsystems/histogram) Rust crate (the canonical implementation) and its [Python](https://github.com/iopsystems/h2histogram-py) and [Go](https://github.com/iopsystems/h2histogram-go) ports.

New exports, parameterized by `groupingPower` / `maxValuePower` (matching the crate):

- **`Config`** — `valueToIndex`, `indexToRange`, `totalBuckets`, `error`, `fromTotalBuckets`.
- **`Histogram`** — dense; `increment`, `record`, `recordMany`, `percentile(s)`, `merge`, `subtract`, `downsample`, `toSparse`, `toCumulative`, `fromBuckets`.
- **`SparseHistogram`** — columnar `(index, count)` form; `fromParts`, `toDense`, `toCumulative`.
- **`CumulativeHistogram`** — read-only cumulative form (the crate's `CumulativeROHistogram`) with binary-search `percentile(s)`, `mean`, `bucketQuantileRange`, `iterWithQuantiles`.
- **`Bucket`** — count + inclusive `[start, end]` range, `midpoint`, `width`.

## Why it's byte-compatible

A canonical `Config(groupingPower, maxValuePower)` is exactly `new H2Encoding({ a: 0, b: groupingPower, n: maxValuePower })` — the canonical implementation always uses width-1 linear buckets. So this layer **reuses the existing, property-tested `H2Encoding`** under the hood rather than reimplementing the math, and produces byte-for-byte identical bucketing. Histograms recorded by Rezolus or the Python/Go implementations load and analyze here directly.

## 53-bit values

Per the task, this is the one deviation from the canonical crate: JavaScript numbers are 64-bit floats, so `maxValuePower` is capped at **53** (values up to `2^53 - 1`) rather than 64. Below that limit the bucketing is identical across all implementations.

## Backward compatibility

The original `{ a, b, n }` API — `H2Encoding`, `H2HistogramBuilder`, `H2Histogram`, `encode32`, `decode32` — is **unchanged**. All existing tests continue to pass.

## Package rename

The npm package is renamed **`h2-histogram` → `h2histogram`** to match the Python package and the `h2histogram-*` repo family. The README carries a deprecation banner pointing old users to the new name, and [`RELEASING.md`](RELEASING.md) documents the publish flow and the one-time `npm deprecate h2-histogram` step. Repository/bugs/homepage URLs (previously pointing at a wrong slug) are corrected.

## Tests

`src/canonical.test.js` cross-checks the new layer against the **Rust crate's `config.rs` assertions** (which are independent of `maxValuePower` below the maximum) and mirrors the Python test suite for the histogram/sparse/cumulative types. `tsc --noEmit` is clean.

```
38 tests passing (32 new + 6 existing)
```

## Versioning

Ships as **`1.2.0`** (final release). Merging this with a `Release 1.2.0` commit on `main` triggers `npm-publish.yml` to publish `h2histogram@1.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H