### PR TITLE
Release 1.2.0: fix npm-publish workflow for the renamed package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,33 +2,36 @@ name: npm-publish
 on:
   push:
     branches:
-      - main # Change this to your default branch
+      - main
 jobs:
   npm-publish:
     name: npm-publish
     runs-on: ubuntu-latest
+    # Publish only on release commits, i.e. those whose message starts with
+    # "Release <version>" (e.g. the squash-merge of a release PR).
+    if: startsWith(github.event.head_commit.message, 'Release ')
     permissions:
       contents: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      #- name: Run tests
-      #  uses: actions/setup-node@v3
-      #  with:
-      #    node-version: '20'
-      #- run: npm ci
-      #- run: npm test
-      - name: Publish if version has been updated
-        uses: pascalgn/npm-publish-action@1.3.9
-        with: # All of theses inputs are optional
-          tag_name: 'v%s'
-          tag_message: 'v%s'
-          create_tag: 'true'
-          commit_pattern: "^Release (\\S+)"
-          workspace: '.'
-          publish_command: 'yarn'
-          publish_args: '--non-interactive'
-        env: # More info about the environment variables in the README
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npx vitest run
+      - name: Publish to npm
+        # `npm publish` (unlike `yarn publish`) handles the first-ever publish of
+        # a new package name, which `yarn` aborts on with a registry 404.
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Tag the release
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          git tag -a "$VERSION" -m "$VERSION" || true
+          git push origin "$VERSION" || true

--- a/README.md
+++ b/README.md
@@ -114,3 +114,15 @@ cumulative.percentile(0.999);
 | `CumulativeHistogram` | Read-only cumulative form (crate's `CumulativeROHistogram`); binary-search `percentile(s)`, `mean`, `bucketQuantileRange`, `iterWithQuantiles` |
 | `Bucket` | A bucket's `count` and inclusive `[start, end]` range, plus `midpoint`/`width` |
 | `H2Encoding`, `H2HistogramBuilder`, `H2Histogram`, `encode32`, `decode32` | The original `{ a, b, n }` API (unchanged) |
+
+## Related implementations
+
+The h2 histogram bucketing is implemented in several languages, all producing
+byte-for-byte identical buckets so histograms interoperate across them:
+
+- [**Rust**](https://github.com/iopsystems/histogram) — the canonical
+  implementation (`histogram` crate)
+- [**Python**](https://github.com/iopsystems/h2histogram-py)
+- [**Go**](https://github.com/iopsystems/h2histogram-go)
+- [**JavaScript**](https://github.com/iopsystems/h2histogram-js) — this
+  repository (values up to `2^53 - 1`)


### PR DESCRIPTION
## Why

The `Release 1.2.0` merge (#5) renamed the npm package `h2-histogram` → `h2histogram`, but the publish **failed**: the workflow used `yarn publish`, and yarn classic aborts on the first-ever publish of a new package name with a registry 404:

```
error Couldn't publish package: "https://registry.yarnpkg.com/h2histogram: Not found"
```

(The old `h2-histogram` published fine only because it already existed.) The `v1.2.0` git tag was created, but nothing was published to npm, so `1.2.0` is still free on the registry.

## Fix

Replace the `pascalgn/npm-publish-action` (which injects a yarn-only `--new-version` flag and can't cleanly drive npm) with a standard `actions/setup-node` + `npm publish --access public`. `npm publish` handles first-time publishes of a new package name. Publishing stays gated to release commits via `if: startsWith(github.event.head_commit.message, 'Release ')`, and the git-tagging behavior is preserved.

Also adds a **Related implementations** section to the README linking the canonical [Rust `histogram` crate](https://github.com/iopsystems/histogram) and the Python/Go ports.

## Effect

Merging this as a `Release 1.2.0` commit re-runs the (now fixed) workflow and publishes `h2histogram@1.2.0`.

> **Note:** this assumes the `NPM_AUTH_TOKEN` secret is an account/automation token allowed to create new packages (it already publishes under this account). If it's a granular token scoped only to the old `h2-histogram`, the first publish of `h2histogram` will need the token re-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H)_