### PR TITLE
Release 1.2.0: keep the h2-histogram name (abandon rename)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-# h2histogram
-
-> **Renamed:** this package was previously published as
-> [`h2-histogram`](https://www.npmjs.com/package/h2-histogram). It now lives at
-> [`h2histogram`](https://www.npmjs.com/package/h2histogram) to match the
-> [Python](https://github.com/iopsystems/h2histogram-py) and
-> [Go](https://github.com/iopsystems/h2histogram-go) packages. Install with
-> `npm install h2histogram`; the old `h2-histogram` package is deprecated and
-> will not receive further updates.
-
 The H2Histogram provides a histogram that is conceptually similar to
 [HdrHistogram](http://hdrhistogram.org) but with base-2 buckets, which makes it
 noticeably faster. This introduces small modifications to the configurable
@@ -58,7 +48,7 @@ bucketing is identical across all implementations.
 ## Canonical API quick start
 
 ```js
-import { Histogram } from 'h2histogram';
+import { Histogram } from 'h2-histogram';
 
 const h = new Histogram(7, 53); // groupingPower, maxValuePower (default 53)
 h.increment(42);
@@ -96,7 +86,7 @@ for (const [bucket, lo, hi] of c.iterWithQuantiles()) {
 ### Interop with columnar (Rezolus) data
 
 ```js
-import { Config, SparseHistogram, CumulativeHistogram } from 'h2histogram';
+import { Config, SparseHistogram, CumulativeHistogram } from 'h2-histogram';
 
 const config = new Config(3, 53);                 // Rezolus-style config
 const sparse = SparseHistogram.fromParts(config, bucketIndices, bucketCounts);

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,11 @@
 # Releasing
 
-`h2histogram` is published to [npm](https://www.npmjs.com/package/h2histogram)
+`h2-histogram` is published to [npm](https://www.npmjs.com/package/h2-histogram)
 by the [`npm-publish.yml`](.github/workflows/npm-publish.yml) GitHub Actions
-workflow. The workflow runs on every push to `main` and publishes **only when
-the head commit message matches `Release <version>` and the `package.json`
-version has changed**. It authenticates with the `NPM_AUTH_TOKEN` repository
-secret.
+workflow. The workflow runs on pushes to `main` and publishes **only when the
+head commit message starts with `Release `** (e.g. the squash-merge of a release
+PR). It authenticates with the `NPM_AUTH_TOKEN` repository secret, which must be
+a token allowed to publish this package.
 
 ## Cutting a release
 
@@ -13,36 +13,32 @@ secret.
    [semantic versioning](https://semver.org/) (e.g. `1.2.0` → `1.2.1` for fixes,
    `1.3.0` for backwards-compatible features). Do this on a branch and open a PR.
 2. **Land a `Release <version>` commit on `main`.** The publish trigger keys off
-   the commit *message*, so the commit that updates `package.json` (or the squash
-   merge) must be titled exactly:
+   the commit *message*, so the commit that lands on `main` (e.g. the squash-merge
+   title) must start with `Release `:
 
    ```
    Release 1.2.0
    ```
 
-   When it hits `main`, the workflow builds and runs `yarn publish`, then creates
-   a `v1.2.0` git tag.
+   When it hits `main`, the workflow installs, runs the tests, runs
+   `npm publish --access public`, and pushes a `v<version>` git tag.
 3. **Verify.** Within a minute or so:
 
    ```bash
-   npm view h2histogram version   # -> 1.2.0
-   npm install h2histogram
+   npm view h2-histogram version   # -> 1.2.0
+   npm install h2-histogram
    ```
 
 > **Versions are immutable on npm.** A published version can never be
 > re-uploaded, only [deprecated](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions).
 > If you ship a bad release, bump the version and cut a new one.
 
-## The `h2-histogram` → `h2histogram` rename (one-time)
+## Publishing manually
 
-This package was previously published as
-[`h2-histogram`](https://www.npmjs.com/package/h2-histogram). After the first
-`h2histogram` release, deprecate the old package so installs surface a pointer
-(run once, from an account with publish rights to the old package):
+If you need to publish outside CI (e.g. from a maintainer's machine):
 
 ```bash
-npm deprecate h2-histogram "renamed to h2histogram — install h2histogram instead"
+npm install
+npm test
+npm publish --access public   # add --otp=<code> if your account enforces 2FA
 ```
-
-This does not unpublish the old package (existing installs keep working); it just
-attaches a deprecation warning that npm prints on install.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "type": "module",
-  "name": "h2histogram",
+  "name": "h2-histogram",
   "version": "1.2.0",
   "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations. Byte-for-byte compatible with the iopsystems histogram Rust crate and its Python/Go ports.",
   "main": "src/index.js",
   "scripts": {
     "test": "vitest",
-    "build": "esbuild src/index.js --bundle --format=esm --outfile=dist/h2histogram.js"
+    "build": "esbuild src/index.js --bundle --format=esm --outfile=dist/h2-histogram.js"
   },
   "keywords": [],
   "author": "Yuri Vishnevsky",


### PR DESCRIPTION
## Why

The attempted rename `h2-histogram` → `h2histogram` can't be published: npm's **name-similarity policy** rejects the new unscoped name because it's too close to the existing `h2-histogram`:

```
npm error 403 Package name too similar to existing package h2-histogram;
try renaming your package to '@thinkingfish/h2histogram'
```

Rather than move to a scoped name, we're keeping `h2-histogram`. (The `403` confirms the `NPM_AUTH_TOKEN` secret now authenticates correctly — only the name was rejected.)

## Changes

Reverts the naming bits back to `h2-histogram`:
- `package.json` `name` and build output filename
- README install/import examples (`from 'h2-histogram'`) and removal of the rename banner
- `RELEASING.md` (removes the rename/deprecation section; corrects it to describe the current `npm publish` workflow)

**Kept** from the 1.2.0 work: the canonical-compatible API (`Config`/`Histogram`/`SparseHistogram`/`CumulativeHistogram`/`Bucket`), the corrected repository URLs, the **Related implementations** section, and the fixed publish workflow (`npm publish`).

## Effect

Merging as a `Release 1.2.0` commit publishes **`h2-histogram@1.2.0`** — a normal version bump on the existing package (no similarity issue, no deprecation needed). 38 tests pass; `tsc` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H)_