### PR TITLE
Switch npm publishing to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,11 @@ jobs:
     # "Release <version>" (e.g. the squash-merge of a release PR).
     if: startsWith(github.event.head_commit.message, 'Release ')
     permissions:
+      # id-token: write lets the workflow mint an OIDC token so npm can
+      # authenticate the publish via Trusted Publishing (no NPM token needed)
+      # and attach a provenance attestation.
+      id-token: write
+      # contents: write lets the "Tag the release" step push the git tag.
       contents: write
     steps:
       - name: Checkout repository
@@ -18,18 +23,19 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm (Trusted Publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: npm install
       - name: Run tests
         run: npx vitest run
-      - name: Publish to npm
-        # `npm publish` (unlike `yarn publish`) handles the first-ever publish of
-        # a new package name, which `yarn` aborts on with a registry 404.
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Publish to npm (Trusted Publishing + provenance)
+        # No NODE_AUTH_TOKEN: authentication happens over OIDC against the
+        # trusted publisher registered for this package on npmjs.com
+        # (repo iopsystems/h2histogram-js, workflow npm-publish.yml).
+        run: npm publish --access public --provenance
       - name: Tag the release
         run: |
           VERSION="v$(node -p "require('./package.json').version")"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,28 @@
 by the [`npm-publish.yml`](.github/workflows/npm-publish.yml) GitHub Actions
 workflow. The workflow runs on pushes to `main` and publishes **only when the
 head commit message starts with `Release `** (e.g. the squash-merge of a release
-PR). It authenticates with the `NPM_AUTH_TOKEN` repository secret, which must be
-a token allowed to publish this package.
+PR).
+
+It authenticates with npm **[Trusted Publishing](https://docs.npmjs.com/trusted-publishers)**
+(OIDC) — there is **no npm token** stored as a repository secret. The workflow
+mints a short-lived OIDC identity token that npm verifies against the trusted
+publisher registered for this package, and it attaches a
+[provenance attestation](https://docs.npmjs.com/generating-provenance-statements)
+to each publish.
+
+### One-time setup (Trusted Publishing)
+
+On [npmjs.com → the `h2-histogram` package → Settings](https://www.npmjs.com/package/h2-histogram/access),
+under **Trusted Publisher**, add a GitHub Actions publisher:
+
+| Field           | Value                        |
+|-----------------|------------------------------|
+| Organization    | `iopsystems`                 |
+| Repository      | `h2histogram-js`             |
+| Workflow name   | `npm-publish.yml`            |
+| Environment     | *(leave blank)*              |
+
+Once registered, the `NPM_AUTH_TOKEN` repository secret can be deleted.
 
 ## Cutting a release
 
@@ -20,8 +40,9 @@ a token allowed to publish this package.
    Release 1.2.0
    ```
 
-   When it hits `main`, the workflow installs, runs the tests, runs
-   `npm publish --access public`, and pushes a `v<version>` git tag.
+   When it hits `main`, the workflow installs, runs the tests, publishes via
+   Trusted Publishing (`npm publish --access public --provenance`), and pushes a
+   `v<version>` git tag.
 3. **Verify.** Within a minute or so:
 
    ```bash


### PR DESCRIPTION
## Summary

Replaces the `NPM_AUTH_TOKEN` secret with npm **[Trusted Publishing](https://docs.npmjs.com/trusted-publishers)** (OIDC), so releases publish **tokenlessly** and with a **provenance attestation**.

Workflow changes (`npm-publish.yml`):
- Add `permissions: id-token: write` (mint the OIDC token) alongside `contents: write` (git tag).
- Drop the `NODE_AUTH_TOKEN` / `NPM_AUTH_TOKEN` env — auth is now the OIDC exchange.
- Upgrade npm in CI (`npm install -g npm@latest`) to meet Trusted Publishing's minimum version.
- Publish with `npm publish --access public --provenance`.

`RELEASING.md` documents the flow and the one-time registration.

## ⚠️ Required before this works: register the trusted publisher on npmjs.com

This PR is the **workflow half**. Trusted Publishing also needs a one-time registration on the package (only a package owner can do it). On **npmjs.com → `h2-histogram` → Settings → Trusted Publisher**, add a GitHub Actions publisher:

| Field | Value |
|---|---|
| Organization | `iopsystems` |
| Repository | `h2histogram-js` |
| Workflow name | `npm-publish.yml` |
| Environment | *(leave blank)* |

After that's registered, the next `Release x.y.z` merge publishes over OIDC, and the `NPM_AUTH_TOKEN` secret can be deleted.

## Notes

- This is safe to merge before registering — it only runs on `Release …` commits, so it won't publish anything on merge. But **don't cut a release until the trusted publisher is registered**, or the OIDC publish will fail.
- `h2-histogram@1.2.0` is already published, so the trusted publisher can be registered on the existing package right now (no first-publish chicken-and-egg).
- Tests pass (38/38) on the updated devDependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H)_