### PR TITLE
Release 1.2.1: add runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ cumulative.percentile(0.999);
 | `Bucket` | A bucket's `count` and inclusive `[start, end]` range, plus `midpoint`/`width` |
 | `H2Encoding`, `H2HistogramBuilder`, `H2Histogram`, `encode32`, `decode32` | The original `{ a, b, n }` API (unchanged) |
 
+## Examples
+
+Runnable examples live in [`examples/`](examples):
+
+- [`basic_usage.js`](examples/basic_usage.js) — record a distribution and query percentiles
+- [`cumulative_quantiles.js`](examples/cumulative_quantiles.js) — fast repeated quantiles, mean, and per-bucket quantile spans via `CumulativeHistogram`
+- [`interop_columnar.js`](examples/interop_columnar.js) — load a histogram from columnar `(index, count)` data (the Rezolus / cross-language storage form)
+
+```bash
+node examples/basic_usage.js
+```
+
 ## Related implementations
 
 The h2 histogram bucketing is implemented in several languages, all producing

--- a/examples/basic_usage.js
+++ b/examples/basic_usage.js
@@ -1,0 +1,43 @@
+// Basic usage: record a distribution of latencies and query percentiles.
+//
+// Run with:  node examples/basic_usage.js
+//
+// (Examples import from the local source; when using the published package,
+// import from 'h2-histogram' instead.)
+
+import { Histogram } from '../src/index.js';
+
+// grouping_power = 7 -> ~0.78% relative error; max_value_power = 30 -> values
+// up to 2^30 - 1 (~1e9), plenty for microsecond latencies.
+const h = new Histogram(7, 30);
+
+// Record 10k synthetic latency samples (in microseconds) from a couple of
+// deterministic modes, so the output is stable across runs.
+for (let i = 0; i < 8000; i++) {
+  // a tight cluster around ~500us
+  h.increment(400 + (i % 200));
+}
+for (let i = 0; i < 2000; i++) {
+  // a heavier tail around ~50ms
+  h.increment(40000 + (i % 20000));
+}
+
+console.log('total samples:', h.totalCount());
+
+for (const q of [0.5, 0.9, 0.99, 1.0]) {
+  const b = h.percentile(q);
+  console.log(
+    `p${(q * 100).toFixed(0).padStart(3)}: ` +
+      `[${b.start}, ${b.end}] us  (midpoint ~${Math.round(b.midpoint)} us, width ${b.width})`
+  );
+}
+
+// You can also fetch several percentiles at once (input order preserved).
+const [[, median], [, tail]] = h.percentiles([0.5, 0.999]);
+console.log(`\nmedian ~${Math.round(median.midpoint)} us, p99.9 ~${Math.round(tail.midpoint)} us`);
+
+// Weighted recording and bulk recording.
+const h2 = new Histogram(7, 30);
+h2.record(1000, 5); // 5 observations of 1000
+h2.recordMany([10, 20, 30, 1000]); // one each
+console.log('\nh2 total:', h2.totalCount(), '(expected 9)');

--- a/examples/cumulative_quantiles.js
+++ b/examples/cumulative_quantiles.js
@@ -1,0 +1,38 @@
+// Fast repeated quantile queries with CumulativeHistogram.
+//
+// Run with:  node examples/cumulative_quantiles.js
+//
+// A CumulativeHistogram (the Rust crate's CumulativeROHistogram) stores only
+// non-zero buckets with cumulative counts, so quantiles are answered with a
+// binary search and a midpoint-estimated mean is precomputed once.
+
+import { Histogram } from '../src/index.js';
+
+const h = new Histogram(5, 20); // coarser buckets keep the printout short
+
+// A simple triangular-ish distribution over [1, 1000].
+for (let v = 1; v <= 1000; v++) {
+  h.record(v, v % 7); // varying weights
+}
+
+const c = h.toCumulative();
+
+console.log('total observations:', c.totalCount());
+console.log('midpoint-estimated mean:', c.mean().toFixed(1));
+
+// O(log n) quantile queries — cheap to call many times.
+for (const q of [0.1, 0.25, 0.5, 0.75, 0.9, 0.99]) {
+  const b = c.percentile(q);
+  console.log(`  q=${q.toFixed(2)} -> value ~${Math.round(b.midpoint)} (bucket [${b.start}, ${b.end}])`);
+}
+
+// Each stored bucket also carries the fraction of data at/below it — handy for
+// drawing a CDF / ECDF.
+console.log('\nfirst few non-zero buckets with their quantile span:');
+let shown = 0;
+for (const [bucket, lo, hi] of c.iterWithQuantiles()) {
+  console.log(
+    `  [${bucket.start}, ${bucket.end}] count=${bucket.count}  quantiles ${lo.toFixed(3)}..${hi.toFixed(3)}`
+  );
+  if (++shown === 5) break;
+}

--- a/examples/interop_columnar.js
+++ b/examples/interop_columnar.js
@@ -1,0 +1,42 @@
+// Interop: load a histogram from columnar (index, count) data.
+//
+// Run with:  node examples/interop_columnar.js
+//
+// This is the shape Rezolus and the Rust/Python/Go implementations use for
+// storage: a Config plus two parallel arrays of non-zero bucket indices and
+// their counts. Because the bucketing is byte-for-byte identical across
+// implementations, a snapshot produced elsewhere loads directly here.
+
+import { Config, Histogram, SparseHistogram } from '../src/index.js';
+
+// Rezolus records with grouping_power = 3. Use max_value_power = 53 (the JS max).
+const config = new Config(3, 53);
+
+// Pretend these came from a parquet column / another implementation.
+// Build them here from a dense histogram so the example is self-contained.
+const source = new Histogram(3, 53);
+source.record(5, 10);
+source.record(500, 42);
+source.record(1_000_000, 7);
+source.record(2 ** 40, 3);
+
+const sparse = source.toSparse();
+const bucketIndices = [...sparse.index];
+const bucketCounts = [...sparse.count];
+console.log('columnar form:');
+console.log('  indices:', bucketIndices);
+console.log('  counts :', bucketCounts);
+
+// ...and load them back through the public columnar entry point.
+const loaded = SparseHistogram.fromParts(config, bucketIndices, bucketCounts);
+console.log('\nloaded total:', loaded.totalCount());
+
+// Query it (via the dense or cumulative view).
+const c = loaded.toCumulative();
+const p99 = c.percentile(0.99);
+console.log(`p99 ~ ${p99.start}..${p99.end}`);
+
+// The index<->value mapping is exposed on Config, matching the Rust crate.
+const idx = config.valueToIndex(1000);
+const [lo, hi] = config.indexToRange(idx);
+console.log(`\nvalue 1000 -> bucket ${idx} covering [${lo}, ${hi}] (total buckets: ${config.totalBuckets})`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "h2-histogram",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The H2Histogram provides a histogram that is conceptually similar to HdrHistogram, but noticeably faster due to the use of base-2 buckets and efficient bit operations. Byte-for-byte compatible with the iopsystems histogram Rust crate and its Python/Go ports.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Adds runnable examples under [`examples/`](examples) and bumps to `1.2.1`.

- **`basic_usage.js`** — record a latency distribution and query percentiles (single + batched, weighted/bulk recording).
- **`cumulative_quantiles.js`** — the fast read-only path: `CumulativeHistogram` with O(log n) quantiles, precomputed `mean()`, and per-bucket quantile spans via `iterWithQuantiles()`.
- **`interop_columnar.js`** — load a histogram from columnar `(index, count)` data through `SparseHistogram.fromParts` — the Rezolus / cross-language storage form — and query it.

README links the examples. All three run clean against the local source (`node examples/*.js`), and the test suite still passes (38/38).

This is also the **first release published via OIDC Trusted Publishing** — merging as `Release 1.2.1` exercises the tokenless publish + provenance path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQS1TmyZmg5tie8QtyFz5H)_